### PR TITLE
Update runGdal.R

### DIFF
--- a/R/runGdal.R
+++ b/R/runGdal.R
@@ -123,6 +123,9 @@ runGdal <- function(product, collection=NULL,
     # absolutly needed
     product <- getProduct(product,quiet=TRUE)
     
+    # force it to use the first product returned
+    product <- lapply(product0, function(x) x[1])
+                      
     # optional and if missing it is added here:
     product$CCC <- getCollection(product,collection=collection)
     tLimits     <- transDate(begin=begin,end=end)


### PR DESCRIPTION
force it to use the first product returned from getProduct by removing the 2nd item in each list element