### PR TITLE
Added extra numerical argument 'maskValue' to runGdal() which is excl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## MODIS 
 
+[![](http://www.r-pkg.org/badges/version/MODIS)](http://www.r-pkg.org/pkg/MODIS)
+
 Acquisition and Processing of MODIS Products
 
 
@@ -7,7 +9,7 @@ Acquisition and Processing of MODIS Products
 
 ### News
 
-**MODIS_1.1.0** is now available for [download](https://cran.r-project.org/package=MODIS). Please refer to [NEWS](https://github.com/MatMatt/MODIS/blob/master/NEWS.md) for a detailed change log.
+**MODIS_1.1.2** is now available for [download](https://cran.r-project.org/package=MODIS). Please refer to [NEWS](https://github.com/MatMatt/MODIS/blob/master/NEWS.md) for a detailed change log.
 
 
 ====
@@ -22,7 +24,7 @@ install.packages("MODIS")
 ```
 
 
-To install the development version of the package, first install **[devtools](https://cran.r-project.org/package=devtools)** and subsequently run
+To install the latest development version, first install **[devtools](https://cran.r-project.org/package=devtools)** and subsequently run
 
 ```S
 devtools::install_github("MatMatt/MODIS", ref = "develop")


### PR DESCRIPTION
…uded from the gdalwarp interpolation via the '-srcnodata' argument.  Note that if a no data value is already specified then this argument is ignored.  Also note that I could only get this working with a single value despite the gdalwarp documentation saying that multiple values are possible.

This modification is extremely useful for me (and I assume others in my position) who just want to whack MODIS data onto raster grids in R using the gdal resample methods.  With this, the package really is a one-stop shop for processing MODIS data.  So I would be really grateful if you adopted this, especially as it doesn't effect existing behaviour.

I also don't fully understand exactly how the '-srcnodata' argument is created by the unmodified code, I am only assuming it is determined from a No Data value in the input SDS (via the getNa() function?).  But I have made sure that if 'srcnodata' is defined, my addition does not overwrite it.

Finally, what would be even more useful would be to allow multiple maskValues, to exclude, for example, water *and* no fill *and* the No Data value from the original SDS.  But I couldn't get that to work, although someone with more GDAL experience might manage.  Or it could probably be done with multiple processing steps.