### PR TITLE
fix issue with gdal-warp

### DIFF
--- a/R/checkTools.R
+++ b/R/checkTools.R
@@ -2,42 +2,42 @@ checkTools = function(
   tool = c("MRT", "GDAL", "wget", "curl")
   , quiet = FALSE
 ) {
-  
+
   tool = tolower(tool)
-  
+
   iw = options()$warn
   options(warn = -1)
   on.exit(options(warn = iw))
-  
-  
+
+
   ### . mrt ----
-  
+
   MRT = if ("mrt" %in% tool) {
     checkMrt(quiet = quiet)
   }
-  
-  
+
+
   ### . gdal ----
-  
+
   GDAL = if ("gdal" %in% tool) {
     checkGdal(quiet = quiet)
   }
-  
-  
+
+
   ### . wget ----
-  
+
   WGET = if ("wget" %in% tool) {
     checkWget()
   }
-  
-  
+
+
   ### . curl ----
-  
+
   CURL = if ("curl" %in% tool) {
     checkCurl()
   }
-  
-  
+
+
   return(
     invisible(
       list(
@@ -55,25 +55,25 @@ checkMrt = function(quiet = FALSE) {
   MRT   <- FALSE
   mrtH  <- normalizePath(Sys.getenv("MRT_HOME"), winslash="/", mustWork = FALSE)
   mrtDD <- normalizePath(Sys.getenv("MRT_DATA_DIR"), winslash="/", mustWork = FALSE)
-  
+
   if (!quiet)
   {
     cat("Checking availability of MRT:\n")
   }
-  
-  if(mrtH=="" & !quiet) 
+
+  if(mrtH=="" & !quiet)
   {
     cat("  'MRT_HOME' not set/found! MRT is NOT enabled! See: 'https://lpdaac.usgs.gov/tools/modis_reprojection_tool'\n")
-  } else 
+  } else
   {
     if (!quiet)
     {
       cat("  'MRT_HOME' found:", mrtH,"\n")
     }
-    if (mrtDD=="" & !quiet) 
+    if (mrtDD=="" & !quiet)
     {
       cat("  'MRT_DATA_DIR' not set/found! MRT is NOT enabled! You need to set the path, read in the MRT manual! 'https://lpdaac.usgs.gov/tools/modis_reprojection_tool'\n")
-    } else 
+    } else
     {
       if (!quiet)
       {
@@ -81,7 +81,7 @@ checkMrt = function(quiet = FALSE) {
         cat("   MRT enabled, settings are fine!\n")
       }
       MRT <- TRUE
-    } 
+    }
   }
   if(MRT)
   {
@@ -96,7 +96,7 @@ checkMrt = function(quiet = FALSE) {
     {
       v <- "Enabled"
     }
-  } else 
+  } else
   {
     v <- "Version not determined"
   }
@@ -124,12 +124,12 @@ checkGdal = function(quiet = FALSE) {
 checkWget = function() {
   WGET = FALSE
   wgetOK = try(system("wget --version", intern = TRUE), silent = TRUE)
-  
+
   wgettext = if (!inherits(wgetOK, "try-error")) {
     WGET = TRUE
     regmatches(wgetOK[1], regexpr("GNU Wget [[:digit:]\\.]+", wgetOK[1]))
   } else ""
-  
+
   list(WGET = WGET, version = wgettext)
 }
 
@@ -137,12 +137,12 @@ checkWget = function() {
 checkCurl = function() {
   CURL = FALSE
   curlOK = try(system("curl --version", intern = TRUE), silent = TRUE)
-  
+
   curltext = if (!inherits(curlOK, "try-error")) {
     CURL = TRUE
     regmatches(curlOK[1], regexpr("curl [[:digit:]\\.]+", curlOK[1]))
   } else ""
-  
+
   list(CURL = CURL, version = curltext)
 }
 
@@ -161,7 +161,7 @@ checkGdalWriteDriver = function(dataFormat) {
     stop("dataFormat = '", dataFormat, "' is MRT specific, "
          , "run MODIS:::getGdalWriteDrivers() for GDAL supported write formats.")
   }
-  nms = getGdalWriteDrivers()$name
+  nms = as.character(getGdalWriteDrivers()$name)
   avl = toupper(dataFormat) == toupper(nms)
   if (!any(avl)) {
     stop("dataFormat = '", dataFormat, "' not recognized by GDAL, "
@@ -178,7 +178,7 @@ checkMrtWriteDriver = function(dataFormat) {
     stop("dataFormat = '", dataFormat, "' not recognized by MRT, "
          , "choose one of c('raw binary', 'HDF-EOS', 'GeoTiff')."
     )
-  } 
+  }
   switch(
     nms[avl]
     , "raw binary" = ".hdr"


### PR DESCRIPTION
First of all thanks for making this repository publicly available. This pull request fixes issues #93 and #92 
The following is a reproducible example on Linux Mint 18.2

```R

sp_path = ebirdst::ebirdst_download("example_data")
abd = ebirdst::load_raster(product = "abundance", sp_path)

mod_date = MODIS::transDate(begin = as.Date('2018-02-01'),
                            end = as.Date('2018-02-02'))

mod_tile = MODIS::getTile(x = abd)

tifs = MODIS::runGdal(product = "MODOCGA",
                      begin = mod_date$beginDOY,
                      end = mod_date$endDOY,
                      tileH = mod_tile@tileH,
                      tileV = mod_tile@tileV,
                      extent = mod_tile, 
                      job = "modis")

```

By running the previous code I received,

```R

Error in sf::gdal_utils(util = "warp", source = gdalSDS, destination = ofile,  : 
  gdal_utils warp: an error occured

```
The error also revealed,

```R

Output driver `79' not recognised or does not support

``` 

The output files in the temporary directory were all of type  ".tif"  (GTIFF  driver).

The [runGdal()](https://github.com/MatMatt/MODIS/blob/master/R/runGdal.R#L101) function calls internally the [sf::gdal_utils()](https://github.com/MatMatt/MODIS/blob/master/R/runGdal.R#L301) function which takes [params](https://github.com/MatMatt/MODIS/blob/master/R/runGdal.R#L306) as input which normally should be a vector of parameters such as,

```R

'-of'  'GTIFF'   etc.

```

however it actually is

```R

'-of'  '79'   etc.

```

In the 'runGdal()' function the 'GTIFF' driver is assigned to the [dataFormat](https://github.com/MatMatt/MODIS/blob/master/R/runGdal.R#L135) variable which equals to

```R

dataFormat = checkGdalWriteDriver(dataFormat)

```

The [checkGdalWriteDriver()](https://github.com/MatMatt/MODIS/blob/master/R/checkTools.R#L159)  function calls internally the [getGdalWriteDrivers()](https://github.com/MatMatt/MODIS/blob/master/R/checkTools.R#L164) function which in my case returns,


```R

'data.frame':	45 obs. of  7 variables:
 $ name     : Factor w/ 210 levels "AAIGrid","ACE2",..: 197 79 129 87 46 117 15 147 148 92 ...
 $ long_name: Factor w/ 209 levels "ACE2","Aeronav FAA",..: 201 68 126 43 36 95 121 152 153 93 ...
 $ write    : logi  TRUE TRUE TRUE TRUE TRUE TRUE ...
 $ copy     : logi  TRUE TRUE TRUE TRUE FALSE FALSE ...
 $ is_raster: logi  TRUE TRUE TRUE TRUE TRUE TRUE ...
 $ is_vector: logi  FALSE FALSE FALSE FALSE FALSE FALSE ...
 $ vsi      : logi  TRUE TRUE TRUE TRUE TRUE FALSE ...

```

Therefore the [nms](https://github.com/MatMatt/MODIS/blob/master/R/checkTools.R#L164) variable,

```R

nms = getGdalWriteDrivers()$name

```

is of type factor and rather than returning the driver as a character string (i.e.  'GTIFF') it returns the level position,

```R

 Factor w/ 210 levels "AAIGrid","ACE2",..: 197 79 129 87 46 117 15 147 148 92 ...

```

In this PR I converted the **nms** variable to a character string as the 'checkGdalWriteDriver()' function is called only once in the MODIS R package.



