### PR TITLE
skip invalid files in runGdal

### DIFF
--- a/R/runGdal.R
+++ b/R/runGdal.R
@@ -241,7 +241,9 @@ runGdal <- function(product, collection=NULL,
             )
             
             files <- files[basename(files)!="NA"] # is not a true NA so it need to be like that na not !is.na()
-            
+            # silently remove empty or invalid files from list
+            if (checkIntegrity) files <- files[checkIntegrity(files)]
+
             if(length(files)>0)
             {
               SDS = lapply(


### PR DESCRIPTION
This pull request fixes the issue #93. If files are empty or otherwise corrupt  and `checkIntegrity == True` (default), they will be silently skipped to avoid an error message in `getSds`.