### PR TITLE
-fixing params for factor variables

### DIFF
--- a/R/runGdal.R
+++ b/R/runGdal.R
@@ -291,7 +291,7 @@ runGdal <- function(product, collection=NULL,
                   
                   params = character()
                   for (j in seq(lst)) {
-                    params = c(params, names(lst)[j], lst[[j]])
+                    params = c(params, names(lst)[j], as.character(lst[[j]]))
                   }
                   
                   ## if required, adjust pixel size and/or target extent


### PR DESCRIPTION
Factor index rather than value was used for parameters given to gdal_utils.

For instance, Geotiff driver was replaced with '79' (its rank in GDAL output drivers) in the arguments passed to gdal_utils leading to an error. Using `as.character` prevents that behaviour.